### PR TITLE
correct gatsby link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ setup correctly you then just need to require the typeface in the entry
 file for your project.
 
 Many tools built with webpack such as
-[Gatsby](github.com/gatsbyjs/gatsby) and [Create React
+[Gatsby](https://github.com/gatsbyjs/gatsby) and [Create React
 App](https://github.com/facebookincubator/create-react-app) are already
 setup to work with Typefaces. Gatsby by default also embeds your CSS in
 your `<head>` for even faster loading.


### PR DESCRIPTION
I got a 404 error page for the link to gatsby repository in the README file.
I add the https:// that was missing.