### PR TITLE
Add docs on basic webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ module.exports = {
 }
 ```
 
+You'll also need to npm install -SD these packages: `style-loader`, `css-loader`, `url-loader`, `file-loader`.
+
 If you’re not using webpack or equivalent tool that allows you to
 require css, then you’ll need to manually integrate the index.css and
 font files from the package into your build system.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ App](https://github.com/facebookincubator/create-react-app) are already
 setup to work with Typefaces. Gatsby by default also embeds your CSS in
 your `<head>` for even faster loading.
 
+## Minimal config
+
+If you don't have Webpack config for CSS loading already, here's a minimalistic webpack.config.js config:
+```
+module.exports = {
+  module: {
+    loaders: [
+      {
+        test: /\.css$/,
+        loader:'style!css!'
+      },
+      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader" },
+      { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader" },
+    ],
+  },
+}
+```
+
 If you’re not using webpack or equivalent tool that allows you to
 require css, then you’ll need to manually integrate the index.css and
 font files from the package into your build system.


### PR DESCRIPTION
I didn't have webpack set up for a Polymer project I'm working on and it took a bit of time to get the right config to use typefaces. Might save other people some time if we add some sample config.