### PR TITLE
Fix typo in templates.js

### DIFF
--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -51,7 +51,7 @@ The CSS and web font files to easily self-host “<%= typefaceName %>”.
 
 Typefaces assume you’re using webpack to process CSS and files. Each typeface
 package includes all necessary font files (woff2, woff, eot, ttf, svg) and
-a CSS file with font-face declerations pointing at these files.
+a CSS file with font-face declarations pointing at these files.
 
 You will need to have webpack setup to load css and font files. Many tools built
 with Webpack will work out of the box with Typefaces such as [Gatsby](https://github.com/gatsbyjs/gatsby)


### PR DESCRIPTION
I fixed this typo in templates.js and left the font README files as-is. I assume next build they'll all be regenerated from the template. 👍 