### PR TITLE
Added ES6 import

### DIFF
--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -63,6 +63,8 @@ To use, simply require the package in your project’s entry file e.g.
 \`\`\`javascript
 // Load <%= typefaceName %> typeface
 require('typeface-<%= typefaceId %>')
+OR
+import 'typeface-<%= typefaceId %>';
 \`\`\`
 
 ## About the Typefaces project.


### PR DESCRIPTION
It might be confusing for some, to see if this only works with require(). 
and since ES6 import is now the more standard way, it would be useful to have it there. 

Thanks