### PR TITLE
Add SCSS support (for configuring font paths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ And that’s it! You’re now self-hosting Open Sans!
 
 It should take < 5 minutes to swap out Google Fonts.
 
-Typeface assumes you’re using webpack with loaders setup for loading css
+Typeface assumes you’re using webpack with loaders setup for loading CSS
 and font files (you can use Typeface with other setups but webpack makes
 things really really simple). Assuming your webpack configuration is
 setup correctly you then just need to require the typeface in the entry
@@ -66,8 +66,8 @@ setup to work with Typefaces. Gatsby by default also embeds your CSS in
 your `<head>` for even faster loading.
 
 If you’re not using webpack or equivalent tool that allows you to
-require css, then you’ll need to manually integrate the index.css and
-font files from the package into your build system.
+require CSS or SCSS, then you’ll need to manually integrate the `index.css` or
+`typeface.scss` and font files from the package into your build system.
 
 ### Alternatives without Webpack
 

--- a/how-to-update.md
+++ b/how-to-update.md
@@ -1,4 +1,4 @@
 ## Google fonts
 
-1. Start google-webfonts-helper locally. It's a separate repo you need to clone and setup
+1. Start [`google-webfonts-helper`](https://github.com/majodev/google-webfonts-helper) locally. It's a separate repo you need to clone and setup.
 2. Run `node scripts/download-all-google-fonts.js`

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -38,11 +38,17 @@ exports.fontFace = _.template(
 `
 )
 
+exports.scssHeader = _.template(
+  `$<%= typefaceId %>-font-path: "./files" !default;
+
+`
+)
+
 exports.readme = _.template(
   `
 # typeface-<%= typefaceId %>
 
-The CSS and web font files to easily self-host “<%= typefaceName %>”.
+The CSS/SCSS and web font files to easily self-host “<%= typefaceName %>”.
 
 ## Install
 
@@ -50,19 +56,34 @@ The CSS and web font files to easily self-host “<%= typefaceName %>”.
 
 ## Use
 
-Typefaces assume you’re using webpack to process CSS and files. Each typeface
-package includes all necessary font files (woff2, woff) and a CSS file with
+Typefaces assume you’re using webpack to process CSS or SCSS and files. Each typeface
+package includes all necessary font files (woff2, woff) and CSS/SCSS files with
 font-face declarations pointing at these files.
 
-You will need to have webpack setup to load css and font files. Many tools built
+You will need to have webpack setup to load CSS or SCSS and font files. Many tools built
 with Webpack will work out of the box with Typefaces such as [Gatsby](https://github.com/gatsbyjs/gatsby)
 and [Create React App](https://github.com/facebookincubator/create-react-app).
 
-To use, simply require the package in your project’s entry file e.g.
+To use, simply require the package in your project’s JavaScript, such as in an entry file:
 
 \`\`\`javascript
 // Load <%= typefaceName %> typeface
 require('typeface-<%= typefaceId %>')
+\`\`\`
+
+You can also use Typefaces directly from SCSS as well:
+
+\`\`\`scss
+// Load <%= typefaceName %> typeface
+@import "typeface-<%= typefaceId %>";
+\`\`\`
+
+Optionally, you can define a custom path to the underlying font files from SCSS like
+so, ensuring that you import the specific \`typeface\` partial:
+
+\`\`\`scss
+$<%= typefaceId %>-font-path: "../path/to/fonts" !default;
+@import "typeface-<%= typefaceId %>/typeface";
 \`\`\`
 
 ## About the Typefaces project.


### PR DESCRIPTION
This implements #79.

This adds support to typeface packages by adding `_typeface.scss` partial for setting a font-path variable. This is to enable support of Sass-centric build systems (eg sass directly, Bootstrap, etc) where files will be copied/put into a known location by another process (but not 'discovered' as in webpack).

The implementation means this is possible:

```scss
$open-sans-font-path:          "../dist/fonts/open-sans" !default;
@import "typeface-open-sans/typeface";
```

and the resulting CSS is populated with the correct font-path as set.

The naming of the imported partial is arbitrary -- it could just as easily be `fonts` or something else, but `typeface` seemed logical since it is the whole typeface.  Ideally, it would have been ideal to name it `index.scss` or `_index.scss` to enable a simple `@import "typeface-open-sans"` from within Sass, but this causes ambiguity with the existing `index.css` file.  As such, Sass won't build if both files are present (it used to be a warning and is now an error).

The choice to have typeface-specific variable names (eg `$open-sans-font-path`) gives flexibility over one generic `$font-path` variable so you can set different paths for different typefaces.  Plus, being more specific means less chance of a conflict in existing projects.

The implementation in the code itself adds only a few minor changes to the build script and templates. There are no changes to the existing CSS builds for full backward compatibility.