### PR TITLE
Update deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
->The Typefaces project is now deprecated.
+> The Typefaces project is now deprecated.
 >
->@DecliningLotus created
+> @DecliningLotus created
 [FontSource](https://github.com/fontsource/fontsource) which provides the
 same functionality as Typefaces but with automated releases & richer
 support for importing specific weights, styles, or language subsets.
 >
->To start using Fontsource, replace in your package.json any instances of
-"typeface-*" with "fontsource-*".
+> To start using Fontsource, replace in your package.json any instances of
+"typeface-*" with "@fontsource/*".
 >
-> Then change imports from e.g. "import 'typeface-roboto'" to "import 'fontsource-roboto/latin.css'".
+> Then change imports from e.g. "import 'typeface-roboto'" to "import '@fontsource/roboto/latin.css'".
 >
->Typeface packages will continue working indefinitely so no immediate
+> Typeface packages will continue working indefinitely so no immediate
 >changes are necessary.
 
 # Typefaces


### PR DESCRIPTION
Fontsource v4 was released a few days ago and they changed the package naming convention from `fontsource-...` to `@fontsource/...`:
https://github.com/fontsource/fontsource/blob/master/CHANGELOG.md#40x